### PR TITLE
Feat/#11/기억분석

### DIFF
--- a/src/main/java/ReDay/analysis/application/dto/response/ActivityTypeItem.java
+++ b/src/main/java/ReDay/analysis/application/dto/response/ActivityTypeItem.java
@@ -1,0 +1,4 @@
+package ReDay.analysis.application.dto.response;
+
+public record ActivityTypeItem(String activityType, int percentage) {
+}

--- a/src/main/java/ReDay/analysis/application/dto/response/MemoryTrendItem.java
+++ b/src/main/java/ReDay/analysis/application/dto/response/MemoryTrendItem.java
@@ -1,0 +1,4 @@
+package ReDay.analysis.application.dto.response;
+
+public record MemoryTrendItem(int year, int month, long count) {
+}

--- a/src/main/java/ReDay/analysis/application/dto/response/MonthlyAnalysisResponse.java
+++ b/src/main/java/ReDay/analysis/application/dto/response/MonthlyAnalysisResponse.java
@@ -1,0 +1,13 @@
+package ReDay.analysis.application.dto.response;
+
+import java.util.List;
+
+public record MonthlyAnalysisResponse(
+        String monthlyInsight,
+        List<MemoryTrendItem> memoryTrend,
+        List<RecordTypeStatItem> recordTypeStats,
+        List<ActivityTypeItem> topActivities,
+        List<PlaceFrequencyItem> topPlaces,
+        List<PersonFrequencyItem> topPeople
+) {
+}

--- a/src/main/java/ReDay/analysis/application/dto/response/PersonFrequencyItem.java
+++ b/src/main/java/ReDay/analysis/application/dto/response/PersonFrequencyItem.java
@@ -1,0 +1,4 @@
+package ReDay.analysis.application.dto.response;
+
+public record PersonFrequencyItem(int rank, String name, int count) {
+}

--- a/src/main/java/ReDay/analysis/application/dto/response/PlaceFrequencyItem.java
+++ b/src/main/java/ReDay/analysis/application/dto/response/PlaceFrequencyItem.java
@@ -1,0 +1,4 @@
+package ReDay.analysis.application.dto.response;
+
+public record PlaceFrequencyItem(int rank, String place, long count) {
+}

--- a/src/main/java/ReDay/analysis/application/dto/response/RecordTypeStatItem.java
+++ b/src/main/java/ReDay/analysis/application/dto/response/RecordTypeStatItem.java
@@ -1,0 +1,4 @@
+package ReDay.analysis.application.dto.response;
+
+public record RecordTypeStatItem(String recordType, long count, double percentage) {
+}

--- a/src/main/java/ReDay/analysis/application/mapper/AnalysisMapper.java
+++ b/src/main/java/ReDay/analysis/application/mapper/AnalysisMapper.java
@@ -1,0 +1,40 @@
+package ReDay.analysis.application.mapper;
+
+import ReDay.analysis.application.dto.response.ActivityTypeItem;
+import ReDay.analysis.application.dto.response.MemoryTrendItem;
+import ReDay.analysis.application.dto.response.MonthlyAnalysisResponse;
+import ReDay.analysis.application.dto.response.PersonFrequencyItem;
+import ReDay.analysis.application.dto.response.PlaceFrequencyItem;
+import ReDay.analysis.application.dto.response.RecordTypeStatItem;
+import ReDay.analysis.domain.entity.MonthlyInsight;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AnalysisMapper {
+
+    private AnalysisMapper() {
+    }
+
+    public static MonthlyAnalysisResponse toMonthlyAnalysisResponse(
+            List<MemoryTrendItem> trend,
+            List<RecordTypeStatItem> recordTypeStats,
+            List<PlaceFrequencyItem> topPlaces,
+            MonthlyInsight insight) {
+
+        if (insight == null) {
+            return new MonthlyAnalysisResponse(null, trend, recordTypeStats, List.of(), topPlaces, List.of());
+        }
+
+        List<ActivityTypeItem> activities = insight.getTopActivities().stream()
+                .map(a -> new ActivityTypeItem(a.getActivityType(), a.getPercentage()))
+                .toList();
+
+        List<PersonFrequencyItem> people = new ArrayList<>();
+        for (int i = 0; i < insight.getTopPeople().size(); i++) {
+            var p = insight.getTopPeople().get(i);
+            people.add(new PersonFrequencyItem(i + 1, p.getName(), p.getCount()));
+        }
+
+        return new MonthlyAnalysisResponse(insight.getInsightText(), trend, recordTypeStats, activities, topPlaces, people);
+    }
+}

--- a/src/main/java/ReDay/analysis/application/usecase/GenerateMonthlyInsightUseCase.java
+++ b/src/main/java/ReDay/analysis/application/usecase/GenerateMonthlyInsightUseCase.java
@@ -1,0 +1,16 @@
+package ReDay.analysis.application.usecase;
+
+import ReDay.analysis.domain.service.MonthlyInsightSaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GenerateMonthlyInsightUseCase {
+
+    private final MonthlyInsightSaveService monthlyInsightSaveService;
+
+    public void execute(Long userId, int year, int month) {
+        monthlyInsightSaveService.generateAndSave(userId, year, month);
+    }
+}

--- a/src/main/java/ReDay/analysis/application/usecase/GetMonthlyAnalysisUseCase.java
+++ b/src/main/java/ReDay/analysis/application/usecase/GetMonthlyAnalysisUseCase.java
@@ -1,0 +1,30 @@
+package ReDay.analysis.application.usecase;
+
+import ReDay.analysis.application.dto.response.MemoryTrendItem;
+import ReDay.analysis.application.dto.response.MonthlyAnalysisResponse;
+import ReDay.analysis.application.dto.response.PlaceFrequencyItem;
+import ReDay.analysis.application.dto.response.RecordTypeStatItem;
+import ReDay.analysis.application.mapper.AnalysisMapper;
+import ReDay.analysis.domain.entity.MonthlyInsight;
+import ReDay.analysis.domain.service.AnalysisStatGetService;
+import ReDay.analysis.domain.service.MonthlyInsightGetService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetMonthlyAnalysisUseCase {
+
+    private final AnalysisStatGetService analysisStatGetService;
+    private final MonthlyInsightGetService monthlyInsightGetService;
+
+    public MonthlyAnalysisResponse execute(Long userId, int year, int month) {
+        List<MemoryTrendItem> trend = analysisStatGetService.getMemoryTrend(userId);
+        List<RecordTypeStatItem> recordTypeStats = analysisStatGetService.getRecordTypeStats(userId, year, month);
+        List<PlaceFrequencyItem> topPlaces = analysisStatGetService.getTopPlaces(userId, year, month);
+        MonthlyInsight insight = monthlyInsightGetService.findInsight(userId, year, month).orElse(null);
+
+        return AnalysisMapper.toMonthlyAnalysisResponse(trend, recordTypeStats, topPlaces, insight);
+    }
+}

--- a/src/main/java/ReDay/analysis/domain/entity/ActivityEntry.java
+++ b/src/main/java/ReDay/analysis/domain/entity/ActivityEntry.java
@@ -1,0 +1,21 @@
+package ReDay.analysis.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ActivityEntry {
+
+    @Column(name = "activity_type", length = 100)
+    private String activityType;
+
+    @Column(name = "activity_percentage")
+    private int percentage;
+}

--- a/src/main/java/ReDay/analysis/domain/entity/MonthlyInsight.java
+++ b/src/main/java/ReDay/analysis/domain/entity/MonthlyInsight.java
@@ -1,0 +1,60 @@
+package ReDay.analysis.domain.entity;
+
+import ReDay.domain.entity.BaseTimeEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "monthly_insight")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MonthlyInsight extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private int year;
+
+    @Column(nullable = false)
+    private int month;
+
+    @Column(columnDefinition = "TEXT")
+    private String insightText;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "monthly_insight_people", joinColumns = @JoinColumn(name = "insight_id"))
+    private List<PersonEntry> topPeople;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "monthly_insight_activities", joinColumns = @JoinColumn(name = "insight_id"))
+    private List<ActivityEntry> topActivities;
+
+    @Builder
+    private MonthlyInsight(Long userId, int year, int month, String insightText,
+                           List<PersonEntry> topPeople, List<ActivityEntry> topActivities) {
+        this.userId = userId;
+        this.year = year;
+        this.month = month;
+        this.insightText = insightText;
+        this.topPeople = topPeople;
+        this.topActivities = topActivities;
+    }
+}

--- a/src/main/java/ReDay/analysis/domain/entity/PersonEntry.java
+++ b/src/main/java/ReDay/analysis/domain/entity/PersonEntry.java
@@ -1,0 +1,21 @@
+package ReDay.analysis.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PersonEntry {
+
+    @Column(name = "person_name", length = 100)
+    private String name;
+
+    @Column(name = "person_count")
+    private int count;
+}

--- a/src/main/java/ReDay/analysis/domain/repository/MonthlyInsightRepository.java
+++ b/src/main/java/ReDay/analysis/domain/repository/MonthlyInsightRepository.java
@@ -1,0 +1,12 @@
+package ReDay.analysis.domain.repository;
+
+import ReDay.analysis.domain.entity.MonthlyInsight;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlyInsightRepository extends JpaRepository<MonthlyInsight, Long> {
+
+    Optional<MonthlyInsight> findByUserIdAndYearAndMonth(Long userId, int year, int month);
+
+    boolean existsByUserIdAndYearAndMonth(Long userId, int year, int month);
+}

--- a/src/main/java/ReDay/analysis/domain/service/AnalysisStatGetService.java
+++ b/src/main/java/ReDay/analysis/domain/service/AnalysisStatGetService.java
@@ -1,0 +1,85 @@
+package ReDay.analysis.domain.service;
+
+import ReDay.analysis.application.dto.response.MemoryTrendItem;
+import ReDay.analysis.application.dto.response.PlaceFrequencyItem;
+import ReDay.analysis.application.dto.response.RecordTypeStatItem;
+import ReDay.record.domain.entity.Record;
+import ReDay.record.domain.repository.RecordRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalysisStatGetService {
+
+    private static final int TREND_MONTHS = 6;
+    private static final int TOP_PLACES = 5;
+
+    private final RecordRepository recordRepository;
+
+    public List<MemoryTrendItem> getMemoryTrend(Long userId) {
+        LocalDate startDate = LocalDate.now().minusMonths(TREND_MONTHS - 1).withDayOfMonth(1);
+        List<Record> records = recordRepository.findByUserIdAndRecordDateGreaterThanEqual(userId, startDate);
+
+        Map<String, Long> countByMonth = records.stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getRecordDate().getYear() + "-" + r.getRecordDate().getMonthValue(),
+                        Collectors.counting()
+                ));
+
+        List<MemoryTrendItem> trend = new ArrayList<>();
+        for (int i = TREND_MONTHS - 1; i >= 0; i--) {
+            LocalDate target = LocalDate.now().minusMonths(i);
+            String key = target.getYear() + "-" + target.getMonthValue();
+            trend.add(new MemoryTrendItem(target.getYear(), target.getMonthValue(),
+                    countByMonth.getOrDefault(key, 0L)));
+        }
+        return trend;
+    }
+
+    public List<RecordTypeStatItem> getRecordTypeStats(Long userId, int year, int month) {
+        List<Record> records = getRecordsForMonth(userId, year, month);
+        long total = records.size();
+        if (total == 0) return List.of();
+
+        return records.stream()
+                .collect(Collectors.groupingBy(Record::getRecordType, Collectors.counting()))
+                .entrySet().stream()
+                .map(e -> new RecordTypeStatItem(
+                        e.getKey(),
+                        e.getValue(),
+                        Math.round((double) e.getValue() / total * 1000.0) / 10.0
+                ))
+                .sorted(Comparator.comparingLong(RecordTypeStatItem::count).reversed())
+                .collect(Collectors.toList());
+    }
+
+    public List<PlaceFrequencyItem> getTopPlaces(Long userId, int year, int month) {
+        List<Record> records = getRecordsForMonth(userId, year, month);
+
+        AtomicInteger rank = new AtomicInteger(1);
+        return records.stream()
+                .filter(r -> r.getAddress() != null && !r.getAddress().isBlank())
+                .collect(Collectors.groupingBy(Record::getAddress, Collectors.counting()))
+                .entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(TOP_PLACES)
+                .map(e -> new PlaceFrequencyItem(rank.getAndIncrement(), e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private List<Record> getRecordsForMonth(Long userId, int year, int month) {
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+        return recordRepository.findByUserIdAndRecordDateBetween(userId, startDate, endDate);
+    }
+}

--- a/src/main/java/ReDay/analysis/domain/service/MonthlyInsightGetService.java
+++ b/src/main/java/ReDay/analysis/domain/service/MonthlyInsightGetService.java
@@ -1,0 +1,20 @@
+package ReDay.analysis.domain.service;
+
+import ReDay.analysis.domain.entity.MonthlyInsight;
+import ReDay.analysis.domain.repository.MonthlyInsightRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MonthlyInsightGetService {
+
+    private final MonthlyInsightRepository monthlyInsightRepository;
+
+    public Optional<MonthlyInsight> findInsight(Long userId, int year, int month) {
+        return monthlyInsightRepository.findByUserIdAndYearAndMonth(userId, year, month);
+    }
+}

--- a/src/main/java/ReDay/analysis/domain/service/MonthlyInsightSaveService.java
+++ b/src/main/java/ReDay/analysis/domain/service/MonthlyInsightSaveService.java
@@ -1,0 +1,61 @@
+package ReDay.analysis.domain.service;
+
+import ReDay.analysis.domain.entity.ActivityEntry;
+import ReDay.analysis.domain.entity.MonthlyInsight;
+import ReDay.analysis.domain.entity.PersonEntry;
+import ReDay.analysis.domain.repository.MonthlyInsightRepository;
+import ReDay.analysis.infrastructure.AnalysisAiService;
+import ReDay.analysis.infrastructure.AnalysisAiService.AiInsightResult;
+import ReDay.record.domain.entity.Record;
+import ReDay.record.domain.repository.RecordRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyInsightSaveService {
+
+    private final MonthlyInsightRepository monthlyInsightRepository;
+    private final RecordRepository recordRepository;
+    private final AnalysisAiService analysisAiService;
+
+    @Transactional
+    public MonthlyInsight generateAndSave(Long userId, int year, int month) {
+        monthlyInsightRepository.findByUserIdAndYearAndMonth(userId, year, month)
+                .ifPresent(monthlyInsightRepository::delete);
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+        List<Record> records = recordRepository.findByUserIdAndRecordDateBetween(userId, startDate, endDate);
+
+        String recordsText = records.stream()
+                .filter(r -> r.getTextContent() != null && !r.getTextContent().isBlank())
+                .map(r -> "- " + r.getRecordDate() + ": " + r.getTextContent())
+                .collect(Collectors.joining("\n"));
+
+        AiInsightResult result = analysisAiService.generateInsight(year, month, recordsText);
+
+        List<PersonEntry> topPeople = result.topPeople().stream()
+                .map(p -> new PersonEntry(p.name(), p.count()))
+                .collect(Collectors.toList());
+
+        List<ActivityEntry> topActivities = result.topActivities().stream()
+                .map(a -> new ActivityEntry(a.activityType(), a.percentage()))
+                .collect(Collectors.toList());
+
+        MonthlyInsight insight = MonthlyInsight.builder()
+                .userId(userId)
+                .year(year)
+                .month(month)
+                .insightText(result.insight())
+                .topPeople(topPeople)
+                .topActivities(topActivities)
+                .build();
+
+        return monthlyInsightRepository.save(insight);
+    }
+}

--- a/src/main/java/ReDay/analysis/infrastructure/AnalysisAiService.java
+++ b/src/main/java/ReDay/analysis/infrastructure/AnalysisAiService.java
@@ -1,0 +1,83 @@
+package ReDay.analysis.infrastructure;
+
+import ReDay.application.exception.BusinessException;
+import ReDay.application.exception.ErrorCode;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisAiService {
+
+    private final RestClient openAIRestClient;
+    private final ObjectMapper objectMapper;
+
+    private static final String MODEL = "gpt-4o-mini";
+    private static final String SYSTEM_PROMPT = """
+            사용자의 월간 기록을 분석하여 반드시 다음 JSON 형식으로만 응답하세요:
+            {
+              "insight": "이번 달 활동에 대한 2~3문장 한국어 인사이트",
+              "topPeople": [{"name": "이름", "count": 횟수}],
+              "topActivities": [{"activityType": "활동명", "percentage": 비율}]
+            }
+            topPeople은 기록에서 언급된 사람 이름 상위 5명, topActivities는 활동 유형 상위 5개를 내림차순으로 반환하세요.
+            기록이 충분하지 않으면 빈 배열로 반환하세요.
+            """;
+
+    public AiInsightResult generateInsight(int year, int month, String recordsText) {
+        String userMessage = year + "년 " + month + "월 기록:\n" + recordsText;
+
+        Map<String, Object> requestBody = Map.of(
+                "model", MODEL,
+                "messages", List.of(
+                        Map.of("role", "system", "content", SYSTEM_PROMPT),
+                        Map.of("role", "user", "content", userMessage)
+                ),
+                "response_format", Map.of("type", "json_object")
+        );
+
+        try {
+            String responseBody = openAIRestClient.post()
+                    .uri("/v1/chat/completions")
+                    .body(requestBody)
+                    .retrieve()
+                    .body(String.class);
+
+            return parseResponse(responseBody);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INSIGHT_GENERATION_FAILED);
+        }
+    }
+
+    private AiInsightResult parseResponse(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            String content = root.path("choices").get(0).path("message").path("content").asText();
+            JsonNode contentNode = objectMapper.readTree(content);
+
+            String insight = contentNode.path("insight").asText();
+            List<PersonData> people = objectMapper.convertValue(
+                    contentNode.path("topPeople"), new TypeReference<>() {});
+            List<ActivityData> activities = objectMapper.convertValue(
+                    contentNode.path("topActivities"), new TypeReference<>() {});
+
+            return new AiInsightResult(insight, people, activities);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INSIGHT_GENERATION_FAILED);
+        }
+    }
+
+    public record AiInsightResult(String insight, List<PersonData> topPeople, List<ActivityData> topActivities) {}
+
+    public record PersonData(String name, int count) {}
+
+    public record ActivityData(String activityType, int percentage) {}
+}

--- a/src/main/java/ReDay/analysis/presentation/AnalysisController.java
+++ b/src/main/java/ReDay/analysis/presentation/AnalysisController.java
@@ -1,0 +1,48 @@
+package ReDay.analysis.presentation;
+
+import ReDay.analysis.application.dto.response.MonthlyAnalysisResponse;
+import ReDay.analysis.application.usecase.GenerateMonthlyInsightUseCase;
+import ReDay.analysis.application.usecase.GetMonthlyAnalysisUseCase;
+import ReDay.common.response.CommonResponse;
+import ReDay.common.response.ResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Analysis", description = "기억 분석 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/analysis")
+public class AnalysisController {
+
+    private final GetMonthlyAnalysisUseCase getMonthlyAnalysisUseCase;
+    private final GenerateMonthlyInsightUseCase generateMonthlyInsightUseCase;
+
+    @Operation(summary = "월간 분석 조회", description = "월별 기억 추이, 기록 유형 통계, 자주 방문한 장소, 자주 만난 사람, 활동 유형, 월간 인사이트를 조회합니다.")
+    @GetMapping("/monthly")
+    public CommonResponse<MonthlyAnalysisResponse> getMonthlyAnalysis(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam int year,
+            @RequestParam int month) {
+        return CommonResponse.success(ResponseMessage.ANALYSIS_FETCHED,
+                getMonthlyAnalysisUseCase.execute(userId, year, month));
+    }
+
+    @Operation(summary = "월간 인사이트 생성", description = "해당 월의 기록을 AI로 분석하여 인사이트, 자주 만난 사람, 활동 유형을 생성합니다. 기존 인사이트가 있으면 재생성합니다.")
+    @PostMapping("/monthly/insight")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void generateMonthlyInsight(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam int year,
+            @RequestParam int month) {
+        generateMonthlyInsightUseCase.execute(userId, year, month);
+    }
+}

--- a/src/main/java/ReDay/application/exception/ErrorCode.java
+++ b/src/main/java/ReDay/application/exception/ErrorCode.java
@@ -37,7 +37,10 @@ public enum ErrorCode {
 
     // AI
     AI_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 요청 처리 중 오류가 발생했습니다."),
-    STT_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "음성 변환 처리 중 오류가 발생했습니다.");
+    STT_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "음성 변환 처리 중 오류가 발생했습니다."),
+
+    // Analysis
+    INSIGHT_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인사이트 생성에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/ReDay/common/response/ResponseMessage.java
+++ b/src/main/java/ReDay/common/response/ResponseMessage.java
@@ -30,7 +30,10 @@ public enum ResponseMessage {
 
     MEMORY_NOT_FOUND(400, "기억을 찾을 수 없습니다."),
     MEMORY_ACCESS_DENIED(401, "해당 기억에 접근할 권한이 없습니다."),
-    MEMORY_ANALYSIS_FAILED(500, "기억 분석에 실패했습니다.");
+    MEMORY_ANALYSIS_FAILED(500, "기억 분석에 실패했습니다."),
+
+    // Analysis
+    ANALYSIS_FETCHED(600, "분석 조회 성공");
 
     private final int code;
     private final String message;

--- a/src/main/java/ReDay/record/domain/repository/RecordRepository.java
+++ b/src/main/java/ReDay/record/domain/repository/RecordRepository.java
@@ -1,7 +1,13 @@
 package ReDay.record.domain.repository;
 
 import ReDay.record.domain.entity.Record;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
+
+    List<Record> findByUserIdAndRecordDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
+    List<Record> findByUserIdAndRecordDateGreaterThanEqual(Long userId, LocalDate startDate);
 }


### PR DESCRIPTION
- 월간 분석 조회 API (GET /api/analysis/monthly)
  - 월별 기억 추이 (최근 6개월 기록 수 집계)
  - 기록 유형 분포 (TEXT/PHOTO/VOICE 비율)
  - 자주 방문한 장소 Top 5 (Record.address 기반)
- 월간 인사이트 생성 API (POST /api/analysis/monthly/insight)
  - GPT로 자주 만난 사람, 활동 유형, 인사이트 텍스트 생성
  - 결과 monthly_insight 테이블에 캐싱 (재생성 지원)
- analysis 패키지 신규 생성 (domain/application/infrastructure/presentation)
- RecordRepository 쿼리 메서드 추가
- ResponseMessage, ErrorCode에 분석 관련 항목 추가

## ✨ 관련 이슈

- Resolved: #21 

## 🔎 작업 내용

-

<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    - 내용
- 기타 안내 사항 <!--(선택 사항)-->
    - 내용
- 주의해야 할 점 <!--(선택 사항)-->
    - 내용

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
