### PR TITLE
Feat #25 캘린더 날짜별 기억 조회 기능 구현

### DIFF
--- a/src/main/java/ReDay/memory/application/dto/response/MemoryCalendarResponse.java
+++ b/src/main/java/ReDay/memory/application/dto/response/MemoryCalendarResponse.java
@@ -1,0 +1,9 @@
+package ReDay.memory.application.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record MemoryCalendarResponse(
+        List<LocalDate> datesWithMemory
+) {
+}

--- a/src/main/java/ReDay/memory/application/usecase/GetMemoryByDateUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/GetMemoryByDateUseCase.java
@@ -1,0 +1,23 @@
+package ReDay.memory.application.usecase;
+
+import ReDay.memory.application.dto.response.MemoryListResponse;
+import ReDay.memory.application.mapper.MemoryMapper;
+import ReDay.memory.domain.service.MemoryGetService;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetMemoryByDateUseCase {
+
+    private final MemoryGetService memoryGetService;
+
+    public List<MemoryListResponse> execute(LocalDate date) {
+        return memoryGetService.getMemoriesByDate(date)
+                .stream()
+                .map(MemoryMapper::toMemoryListResponse)
+                .toList();
+    }
+}

--- a/src/main/java/ReDay/memory/application/usecase/GetMemoryCalendarUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/GetMemoryCalendarUseCase.java
@@ -1,0 +1,19 @@
+package ReDay.memory.application.usecase;
+
+import ReDay.memory.application.dto.response.MemoryCalendarResponse;
+import ReDay.memory.domain.service.MemoryGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetMemoryCalendarUseCase {
+
+    private final MemoryGetService memoryGetService;
+
+    public MemoryCalendarResponse execute(int year, int month) {
+        return new MemoryCalendarResponse(
+                memoryGetService.getMemoryDatesByYearMonth(year, month)
+        );
+    }
+}

--- a/src/main/java/ReDay/memory/domain/repository/MemoryRepository.java
+++ b/src/main/java/ReDay/memory/domain/repository/MemoryRepository.java
@@ -1,6 +1,7 @@
 package ReDay.memory.domain.repository;
 
 import ReDay.memory.domain.entity.Memory;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,8 @@ public interface MemoryRepository extends JpaRepository<Memory, Long> {
     List<Memory> findAllByOrderByMemoryDateDesc();
 
     List<Memory> findAllByTitleContainingIgnoreCaseOrderByMemoryDateDesc(String keyword);
+
+    List<Memory> findAllByMemoryDate(LocalDate date);
+
+    List<Memory> findAllByMemoryDateBetween(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/ReDay/memory/domain/service/MemoryGetService.java
+++ b/src/main/java/ReDay/memory/domain/service/MemoryGetService.java
@@ -3,6 +3,8 @@ package ReDay.memory.domain.service;
 import ReDay.memory.domain.entity.Memory;
 import ReDay.memory.domain.repository.MemoryRepository;
 import ReDay.memory.application.exception.MemoryNotFoundException;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,5 +26,22 @@ public class MemoryGetService {
 
     public List<Memory> searchMemoryByKeyword(String keyword) {
         return memoryRepository.findAllByTitleContainingIgnoreCaseOrderByMemoryDateDesc(keyword);
+    }
+
+    public List<Memory> getMemoriesByDate(LocalDate date) {
+        return memoryRepository.findAllByMemoryDate(date);
+    }
+
+    public List<LocalDate> getMemoryDatesByYearMonth(int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        return memoryRepository.findAllByMemoryDateBetween(startDate, endDate)
+                .stream()
+                .map(Memory::getMemoryDate)
+                .distinct()
+                .sorted()
+                .toList();
     }
 }

--- a/src/main/java/ReDay/memory/presentation/MemoryController.java
+++ b/src/main/java/ReDay/memory/presentation/MemoryController.java
@@ -7,12 +7,16 @@ import ReDay.memory.application.dto.request.MemorySearchRequest;
 import ReDay.memory.application.dto.response.MemoryDetailResponse;
 import ReDay.memory.application.dto.response.MemoryListResponse;
 import ReDay.memory.application.dto.response.MemorySearchResponse;
+import ReDay.memory.application.dto.response.MemoryCalendarResponse;
 import ReDay.memory.application.usecase.CreateMemoryUseCase;
+import ReDay.memory.application.usecase.GetMemoryByDateUseCase;
+import ReDay.memory.application.usecase.GetMemoryCalendarUseCase;
 import ReDay.memory.application.usecase.GetMemoryDetailUseCase;
 import ReDay.memory.application.usecase.GetMemoryListUseCase;
 import ReDay.memory.application.usecase.SearchMemoryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,6 +37,8 @@ public class MemoryController {
     private final CreateMemoryUseCase createMemoryUseCase;
     private final GetMemoryListUseCase getMemoryListUseCase;
     private final SearchMemoryUseCase searchMemoryUseCase;
+    private final GetMemoryCalendarUseCase getMemoryCalendarUseCase;
+    private final GetMemoryByDateUseCase getMemoryByDateUseCase;
 
     @Operation(summary = "기억 상세 조회", description = "기억 ID를 기준으로 기억 상세 정보를 조회합니다.")
     @GetMapping("/{memoryId}")
@@ -58,8 +64,8 @@ public class MemoryController {
 
     @Operation(summary = "기억 목록 조회", description = "전체 기억 목록을 조회합니다.")
     @GetMapping
-    public CommonResponse<java.util.List<MemoryListResponse>> getMemoryList() {
-        java.util.List<MemoryListResponse> response = getMemoryListUseCase.execute();
+    public CommonResponse<List<MemoryListResponse>> getMemoryList() {
+        List<MemoryListResponse> response = getMemoryListUseCase.execute();
 
         return CommonResponse.success(
                 ResponseMessage.MEMORY_FETCHED,
@@ -75,6 +81,33 @@ public class MemoryController {
         List<MemorySearchResponse> response = searchMemoryUseCase.execute(
                 new MemorySearchRequest(keyword)
         );
+
+        return CommonResponse.success(
+                ResponseMessage.MEMORY_FETCHED,
+                response
+        );
+    }
+
+    @Operation(summary = "캘린더 조회", description = "특정 연월에 기억이 있는 날짜 목록을 조회합니다.")
+    @GetMapping("/calendar")
+    public CommonResponse<MemoryCalendarResponse> getMemoryCalendar(
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        MemoryCalendarResponse response = getMemoryCalendarUseCase.execute(year, month);
+
+        return CommonResponse.success(
+                ResponseMessage.MEMORY_FETCHED,
+                response
+        );
+    }
+
+    @Operation(summary = "날짜별 기억 조회", description = "특정 날짜의 기억 목록을 조회합니다.")
+    @GetMapping("/date")
+    public CommonResponse<List<MemoryListResponse>> getMemoryByDate(
+            @RequestParam LocalDate date
+    ) {
+        List<MemoryListResponse> response = getMemoryByDateUseCase.execute(date);
 
         return CommonResponse.success(
                 ResponseMessage.MEMORY_FETCHED,


### PR DESCRIPTION
## Summary
- 월별 기억이 있는 날짜 목록 조회 API 추가
- 특정 날짜의 기억 목록 조회 API 추가

## Changes
- `MemoryCalendarResponse`: 기억 있는 날짜 목록 응답 DTO 추가
- `GetMemoryCalendarUseCase`: 월별 캘린더 조회 유스케이스 추가
- `GetMemoryByDateUseCase`: 날짜별 기억 조회 유스케이스 추가
- `MemoryGetService`: 날짜 조회 서비스 메서드 추가
- `MemoryRepository`: 날짜 기반 쿼리 메서드 추가
- `MemoryController`: 캘린더/날짜 엔드포인트 추가

## API
- `GET /api/memories/calendar?year={year}&month={month}` - 해당 월에 기억 있는 날짜 목록
- `GET /api/memories/date?date={date}` - 특정 날짜의 기억 목록

## Test plan
- [ ] `GET /api/memories/calendar?year=2026&month=4` 스웨거에서 확인
- [ ] `GET /api/memories/date?date=2026-04-09` 스웨거에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)