### PR TITLE
Feat #27 기억 지도 기능 구현

### DIFF
--- a/src/main/java/ReDay/memory/application/dto/request/MemorySaveRequest.java
+++ b/src/main/java/ReDay/memory/application/dto/request/MemorySaveRequest.java
@@ -8,6 +8,7 @@ public record MemorySaveRequest(
         String description,
         LocalDate memoryDate,
         String emotion,
-        String thumbnailUrl
+        String thumbnailUrl,
+        String location
 ) {
 }

--- a/src/main/java/ReDay/memory/application/dto/request/MemoryUpdateRequest.java
+++ b/src/main/java/ReDay/memory/application/dto/request/MemoryUpdateRequest.java
@@ -8,6 +8,7 @@ public record MemoryUpdateRequest(
         String description,
         LocalDate memoryDate,
         String emotion,
-        String thumbnailUrl
+        String thumbnailUrl,
+        String location
 ) {
 }

--- a/src/main/java/ReDay/memory/application/dto/response/MemoryDetailResponse.java
+++ b/src/main/java/ReDay/memory/application/dto/response/MemoryDetailResponse.java
@@ -11,6 +11,7 @@ public record MemoryDetailResponse(
         LocalDate memoryDate,
         String emotion,
         String thumbnailUrl,
+        String location,
         boolean archived,
         List<MemoryTagResponse> tags,
         List<MemoryRecordResponse> records,

--- a/src/main/java/ReDay/memory/application/dto/response/MemoryListResponse.java
+++ b/src/main/java/ReDay/memory/application/dto/response/MemoryListResponse.java
@@ -8,6 +8,7 @@ public record MemoryListResponse(
         String summary,
         LocalDate memoryDate,
         String emotion,
-        String thumbnailUrl
+        String thumbnailUrl,
+        String location
 ) {
 }

--- a/src/main/java/ReDay/memory/application/dto/response/MemoryMapPinResponse.java
+++ b/src/main/java/ReDay/memory/application/dto/response/MemoryMapPinResponse.java
@@ -1,0 +1,7 @@
+package ReDay.memory.application.dto.response;
+
+public record MemoryMapPinResponse(
+        String location,
+        int memoryCount
+) {
+}

--- a/src/main/java/ReDay/memory/application/mapper/MemoryMapper.java
+++ b/src/main/java/ReDay/memory/application/mapper/MemoryMapper.java
@@ -26,6 +26,7 @@ public class MemoryMapper {
                 memory.getMemoryDate(),
                 memory.getEmotion(),
                 memory.getThumbnailUrl(),
+                memory.getLocation(),
                 memory.isArchived(),
                 List.of(),
                 List.of(),
@@ -40,7 +41,8 @@ public class MemoryMapper {
                 memory.getSummary(),
                 memory.getMemoryDate(),
                 memory.getEmotion(),
-                memory.getThumbnailUrl()
+                memory.getThumbnailUrl(),
+                memory.getLocation()
         );
     }
 

--- a/src/main/java/ReDay/memory/application/usecase/GetMemoryByLocationUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/GetMemoryByLocationUseCase.java
@@ -1,0 +1,22 @@
+package ReDay.memory.application.usecase;
+
+import ReDay.memory.application.dto.response.MemoryListResponse;
+import ReDay.memory.application.mapper.MemoryMapper;
+import ReDay.memory.domain.service.MemoryGetService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetMemoryByLocationUseCase {
+
+    private final MemoryGetService memoryGetService;
+
+    public List<MemoryListResponse> execute(String location) {
+        return memoryGetService.getMemoriesByLocation(location)
+                .stream()
+                .map(MemoryMapper::toMemoryListResponse)
+                .toList();
+    }
+}

--- a/src/main/java/ReDay/memory/application/usecase/GetMemoryMapUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/GetMemoryMapUseCase.java
@@ -1,0 +1,28 @@
+package ReDay.memory.application.usecase;
+
+import ReDay.memory.application.dto.response.MemoryMapPinResponse;
+import ReDay.memory.domain.entity.Memory;
+import ReDay.memory.domain.service.MemoryGetService;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetMemoryMapUseCase {
+
+    private final MemoryGetService memoryGetService;
+
+    public List<MemoryMapPinResponse> execute() {
+        Map<String, Long> locationCountMap = memoryGetService.getMemoriesWithLocation()
+                .stream()
+                .collect(Collectors.groupingBy(Memory::getLocation, Collectors.counting()));
+
+        return locationCountMap.entrySet()
+                .stream()
+                .map(entry -> new MemoryMapPinResponse(entry.getKey(), entry.getValue().intValue()))
+                .toList();
+    }
+}

--- a/src/main/java/ReDay/memory/domain/entity/Memory.java
+++ b/src/main/java/ReDay/memory/domain/entity/Memory.java
@@ -41,6 +41,9 @@ public class Memory extends BaseTimeEntity {
     @Column(length = 255)
     private String thumbnailUrl;
 
+    @Column(length = 255)
+    private String location;
+
     @Column(nullable = false)
     private boolean archived;
 
@@ -52,6 +55,7 @@ public class Memory extends BaseTimeEntity {
             LocalDate memoryDate,
             String emotion,
             String thumbnailUrl,
+            String location,
             boolean archived
     ) {
         this.title = title;
@@ -60,6 +64,7 @@ public class Memory extends BaseTimeEntity {
         this.memoryDate = memoryDate;
         this.emotion = emotion;
         this.thumbnailUrl = thumbnailUrl;
+        this.location = location;
         this.archived = archived;
     }
 
@@ -69,7 +74,8 @@ public class Memory extends BaseTimeEntity {
             String description,
             LocalDate memoryDate,
             String emotion,
-            String thumbnailUrl
+            String thumbnailUrl,
+            String location
     ) {
         this.title = title;
         this.summary = summary;
@@ -77,6 +83,7 @@ public class Memory extends BaseTimeEntity {
         this.memoryDate = memoryDate;
         this.emotion = emotion;
         this.thumbnailUrl = thumbnailUrl;
+        this.location = location;
     }
 
     public void archive() {

--- a/src/main/java/ReDay/memory/domain/repository/MemoryRepository.java
+++ b/src/main/java/ReDay/memory/domain/repository/MemoryRepository.java
@@ -14,4 +14,8 @@ public interface MemoryRepository extends JpaRepository<Memory, Long> {
     List<Memory> findAllByMemoryDate(LocalDate date);
 
     List<Memory> findAllByMemoryDateBetween(LocalDate startDate, LocalDate endDate);
+
+    List<Memory> findAllByLocationIsNotNull();
+
+    List<Memory> findAllByLocation(String location);
 }

--- a/src/main/java/ReDay/memory/domain/service/MemoryGetService.java
+++ b/src/main/java/ReDay/memory/domain/service/MemoryGetService.java
@@ -32,6 +32,14 @@ public class MemoryGetService {
         return memoryRepository.findAllByMemoryDate(date);
     }
 
+    public List<Memory> getMemoriesWithLocation() {
+        return memoryRepository.findAllByLocationIsNotNull();
+    }
+
+    public List<Memory> getMemoriesByLocation(String location) {
+        return memoryRepository.findAllByLocation(location);
+    }
+
     public List<LocalDate> getMemoryDatesByYearMonth(int year, int month) {
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate startDate = yearMonth.atDay(1);

--- a/src/main/java/ReDay/memory/domain/service/MemorySaveService.java
+++ b/src/main/java/ReDay/memory/domain/service/MemorySaveService.java
@@ -22,6 +22,7 @@ public class MemorySaveService {
                 .memoryDate(request.memoryDate())
                 .emotion(request.emotion())
                 .thumbnailUrl(request.thumbnailUrl())
+                .location(request.location())
                 .archived(false)
                 .build();
 

--- a/src/main/java/ReDay/memory/domain/service/MemoryUpdateService.java
+++ b/src/main/java/ReDay/memory/domain/service/MemoryUpdateService.java
@@ -25,6 +25,7 @@ public class MemoryUpdateService {
         var memoryDate = request.memoryDate() != null ? request.memoryDate() : memory.getMemoryDate();
         String emotion = request.emotion() != null ? request.emotion() : memory.getEmotion();
         String thumbnailUrl = request.thumbnailUrl() != null ? request.thumbnailUrl() : memory.getThumbnailUrl();
+        String location = request.location() != null ? request.location() : memory.getLocation();
 
         memory.update(
                 title,
@@ -32,7 +33,8 @@ public class MemoryUpdateService {
                 description,
                 memoryDate,
                 emotion,
-                thumbnailUrl
+                thumbnailUrl,
+                location
         );
 
         return memory;

--- a/src/main/java/ReDay/memory/presentation/MemoryMapController.java
+++ b/src/main/java/ReDay/memory/presentation/MemoryMapController.java
@@ -1,0 +1,50 @@
+package ReDay.memory.presentation;
+
+import ReDay.common.response.CommonResponse;
+import ReDay.common.response.ResponseMessage;
+import ReDay.memory.application.dto.response.MemoryListResponse;
+import ReDay.memory.application.dto.response.MemoryMapPinResponse;
+import ReDay.memory.application.usecase.GetMemoryByLocationUseCase;
+import ReDay.memory.application.usecase.GetMemoryMapUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Memory Map", description = "기억 지도 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/memories/map")
+public class MemoryMapController {
+
+    private final GetMemoryMapUseCase getMemoryMapUseCase;
+    private final GetMemoryByLocationUseCase getMemoryByLocationUseCase;
+
+    @Operation(summary = "지도 핀 목록 조회", description = "기억이 있는 장소 목록과 기억 수를 조회합니다.")
+    @GetMapping
+    public CommonResponse<List<MemoryMapPinResponse>> getMemoryMap() {
+        List<MemoryMapPinResponse> response = getMemoryMapUseCase.execute();
+
+        return CommonResponse.success(
+                ResponseMessage.MEMORY_FETCHED,
+                response
+        );
+    }
+
+    @Operation(summary = "장소별 기억 조회", description = "특정 장소의 기억 목록을 조회합니다.")
+    @GetMapping("/location")
+    public CommonResponse<List<MemoryListResponse>> getMemoryByLocation(
+            @RequestParam String location
+    ) {
+        List<MemoryListResponse> response = getMemoryByLocationUseCase.execute(location);
+
+        return CommonResponse.success(
+                ResponseMessage.MEMORY_FETCHED,
+                response
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Memory 엔티티에 location(장소) 필드 추가
- 지도 화면용 장소 핀 목록 조회 API 구현
- 장소별 기억 목록 조회 API 구현

## Changes
- `Memory` 엔티티: `location` 필드 추가
- `MemorySaveRequest` / `MemoryUpdateRequest`: `location` 필드 추가
- `MemoryListResponse` / `MemoryDetailResponse`: `location` 필드 추가
- `MemoryMapPinResponse`: 장소명 + 기억 수 응답 DTO 추가
- `GetMemoryMapUseCase`: 장소 핀 목록 조회 유스케이스 추가
- `GetMemoryByLocationUseCase`: 장소별 기억 조회 유스케이스 추가
- `MemoryMapController`: 지도 API 컨트롤러 추가

## API
- `GET /api/memories/map` - 기억 있는 장소 핀 목록 + 기억 수
- `GET /api/memories/map/location?location={장소명}` - 특정 장소의 기억 목록

## Test plan
- [ ] `GET /api/memories/map` 스웨거에서 확인
- [ ] `GET /api/memories/map/location?location=한강공원` 스웨거에서 확인

