### PR TITLE
Feat #29 태그 검색 기능 구현

### DIFF
--- a/src/main/java/ReDay/memory/application/dto/response/MemorySearchResponse.java
+++ b/src/main/java/ReDay/memory/application/dto/response/MemorySearchResponse.java
@@ -8,6 +8,7 @@ public record MemorySearchResponse(
         String summary,
         LocalDate memoryDate,
         String emotion,
-        String thumbnailUrl
+        String thumbnailUrl,
+        String location
 ) {
 }

--- a/src/main/java/ReDay/memory/application/dto/response/MemoryTagListResponse.java
+++ b/src/main/java/ReDay/memory/application/dto/response/MemoryTagListResponse.java
@@ -1,0 +1,8 @@
+package ReDay.memory.application.dto.response;
+
+import java.util.List;
+
+public record MemoryTagListResponse(
+        List<String> tags
+) {
+}

--- a/src/main/java/ReDay/memory/application/mapper/MemoryMapper.java
+++ b/src/main/java/ReDay/memory/application/mapper/MemoryMapper.java
@@ -53,7 +53,8 @@ public class MemoryMapper {
                 memory.getSummary(),
                 memory.getMemoryDate(),
                 memory.getEmotion(),
-                memory.getThumbnailUrl()
+                memory.getThumbnailUrl(),
+                memory.getLocation()
         );
     }
 }

--- a/src/main/java/ReDay/memory/application/usecase/GetAllTagsUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/GetAllTagsUseCase.java
@@ -1,0 +1,17 @@
+package ReDay.memory.application.usecase;
+
+import ReDay.memory.application.dto.response.MemoryTagListResponse;
+import ReDay.memory.domain.service.MemoryTagGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllTagsUseCase {
+
+    private final MemoryTagGetService memoryTagGetService;
+
+    public MemoryTagListResponse execute() {
+        return new MemoryTagListResponse(memoryTagGetService.getAllTagNames());
+    }
+}

--- a/src/main/java/ReDay/memory/application/usecase/SearchMemoryByTagUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/SearchMemoryByTagUseCase.java
@@ -1,0 +1,22 @@
+package ReDay.memory.application.usecase;
+
+import ReDay.memory.application.dto.response.MemorySearchResponse;
+import ReDay.memory.application.mapper.MemoryMapper;
+import ReDay.memory.domain.service.MemoryTagGetService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SearchMemoryByTagUseCase {
+
+    private final MemoryTagGetService memoryTagGetService;
+
+    public List<MemorySearchResponse> execute(String tagName) {
+        return memoryTagGetService.getMemoriesByTagName(tagName)
+                .stream()
+                .map(MemoryMapper::toMemorySearchResponse)
+                .toList();
+    }
+}

--- a/src/main/java/ReDay/memory/domain/repository/MemoryTagRepository.java
+++ b/src/main/java/ReDay/memory/domain/repository/MemoryTagRepository.java
@@ -4,10 +4,16 @@ import ReDay.memory.domain.entity.Memory;
 import ReDay.memory.domain.entity.MemoryTag;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemoryTagRepository extends JpaRepository<MemoryTag, Long> {
 
     List<MemoryTag> findAllByMemory(Memory memory);
 
     void deleteAllByMemory(Memory memory);
+
+    List<MemoryTag> findAllByTagName(String tagName);
+
+    @Query("SELECT DISTINCT t.tagName FROM MemoryTag t ORDER BY t.tagName")
+    List<String> findAllDistinctTagNames();
 }

--- a/src/main/java/ReDay/memory/domain/service/MemoryTagGetService.java
+++ b/src/main/java/ReDay/memory/domain/service/MemoryTagGetService.java
@@ -1,0 +1,27 @@
+package ReDay.memory.domain.service;
+
+import ReDay.memory.domain.entity.Memory;
+import ReDay.memory.domain.entity.MemoryTag;
+import ReDay.memory.domain.repository.MemoryTagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemoryTagGetService {
+
+    private final MemoryTagRepository memoryTagRepository;
+
+    public List<String> getAllTagNames() {
+        return memoryTagRepository.findAllDistinctTagNames();
+    }
+
+    public List<Memory> getMemoriesByTagName(String tagName) {
+        return memoryTagRepository.findAllByTagName(tagName)
+                .stream()
+                .map(MemoryTag::getMemory)
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/ReDay/memory/presentation/MemoryController.java
+++ b/src/main/java/ReDay/memory/presentation/MemoryController.java
@@ -8,11 +8,14 @@ import ReDay.memory.application.dto.response.MemoryDetailResponse;
 import ReDay.memory.application.dto.response.MemoryListResponse;
 import ReDay.memory.application.dto.response.MemorySearchResponse;
 import ReDay.memory.application.dto.response.MemoryCalendarResponse;
+import ReDay.memory.application.dto.response.MemoryTagListResponse;
 import ReDay.memory.application.usecase.CreateMemoryUseCase;
+import ReDay.memory.application.usecase.GetAllTagsUseCase;
 import ReDay.memory.application.usecase.GetMemoryByDateUseCase;
 import ReDay.memory.application.usecase.GetMemoryCalendarUseCase;
 import ReDay.memory.application.usecase.GetMemoryDetailUseCase;
 import ReDay.memory.application.usecase.GetMemoryListUseCase;
+import ReDay.memory.application.usecase.SearchMemoryByTagUseCase;
 import ReDay.memory.application.usecase.SearchMemoryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,6 +42,8 @@ public class MemoryController {
     private final SearchMemoryUseCase searchMemoryUseCase;
     private final GetMemoryCalendarUseCase getMemoryCalendarUseCase;
     private final GetMemoryByDateUseCase getMemoryByDateUseCase;
+    private final GetAllTagsUseCase getAllTagsUseCase;
+    private final SearchMemoryByTagUseCase searchMemoryByTagUseCase;
 
     @Operation(summary = "기억 상세 조회", description = "기억 ID를 기준으로 기억 상세 정보를 조회합니다.")
     @GetMapping("/{memoryId}")
@@ -108,6 +113,30 @@ public class MemoryController {
             @RequestParam LocalDate date
     ) {
         List<MemoryListResponse> response = getMemoryByDateUseCase.execute(date);
+
+        return CommonResponse.success(
+                ResponseMessage.MEMORY_FETCHED,
+                response
+        );
+    }
+
+    @Operation(summary = "전체 태그 목록 조회", description = "등록된 모든 태그 목록을 조회합니다.")
+    @GetMapping("/tags")
+    public CommonResponse<MemoryTagListResponse> getAllTags() {
+        MemoryTagListResponse response = getAllTagsUseCase.execute();
+
+        return CommonResponse.success(
+                ResponseMessage.MEMORY_FETCHED,
+                response
+        );
+    }
+
+    @Operation(summary = "태그별 기억 검색", description = "특정 태그가 포함된 기억 목록을 조회합니다.")
+    @GetMapping("/search/tag")
+    public CommonResponse<List<MemorySearchResponse>> searchMemoryByTag(
+            @RequestParam String tagName
+    ) {
+        List<MemorySearchResponse> response = searchMemoryByTagUseCase.execute(tagName);
 
         return CommonResponse.success(
                 ResponseMessage.MEMORY_FETCHED,


### PR DESCRIPTION
## Summary
- 전체 태그 목록 조회 API 구현
- 태그별 기억 검색 API 구현
- MemorySearchResponse에 location 필드 추가

## Changes
- `MemoryTagRepository`: 태그명별 조회, 전체 태그명 중복 제거 조회 쿼리 추가
- `MemoryTagGetService`: 태그 관련 서비스 추가
- `MemoryTagListResponse`: 태그 목록 응답 DTO 추가
- `GetAllTagsUseCase`: 전체 태그 목록 조회 유스케이스 추가
- `SearchMemoryByTagUseCase`: 태그별 기억 검색 유스케이스 추가
- `MemorySearchResponse`: location 필드 추가
- `MemoryController`: 태그 관련 엔드포인트 추가

## API
- `GET /api/memories/tags` - 전체 태그 목록 조회
- `GET /api/memories/search/tag?tagName={태그명}` - 태그별 기억 검색

## Test plan
- [x] `GET /api/memories/tags` 스웨거에서 확인
- [x] `GET /api/memories/search/tag?tagName=여행` 스웨거에서 확인

