### PR TITLE
feat: 장소별 기억 검색 API 구현

### DIFF
--- a/src/main/java/ReDay/memory/application/usecase/SearchMemoryByLocationUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/SearchMemoryByLocationUseCase.java
@@ -1,0 +1,22 @@
+package ReDay.memory.application.usecase;
+
+import ReDay.memory.application.dto.response.MemorySearchResponse;
+import ReDay.memory.application.mapper.MemoryMapper;
+import ReDay.memory.domain.service.MemoryGetService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SearchMemoryByLocationUseCase {
+
+    private final MemoryGetService memoryGetService;
+
+    public List<MemorySearchResponse> execute(String location) {
+        return memoryGetService.getMemoriesByLocation(location)
+                .stream()
+                .map(MemoryMapper::toMemorySearchResponse)
+                .toList();
+    }
+}

--- a/src/main/java/ReDay/memory/presentation/MemoryController.java
+++ b/src/main/java/ReDay/memory/presentation/MemoryController.java
@@ -15,6 +15,7 @@ import ReDay.memory.application.usecase.GetMemoryByDateUseCase;
 import ReDay.memory.application.usecase.GetMemoryCalendarUseCase;
 import ReDay.memory.application.usecase.GetMemoryDetailUseCase;
 import ReDay.memory.application.usecase.GetMemoryListUseCase;
+import ReDay.memory.application.usecase.SearchMemoryByLocationUseCase;
 import ReDay.memory.application.usecase.SearchMemoryByTagUseCase;
 import ReDay.memory.application.usecase.SearchMemoryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +45,7 @@ public class MemoryController {
     private final GetMemoryByDateUseCase getMemoryByDateUseCase;
     private final GetAllTagsUseCase getAllTagsUseCase;
     private final SearchMemoryByTagUseCase searchMemoryByTagUseCase;
+    private final SearchMemoryByLocationUseCase searchMemoryByLocationUseCase;
 
     @Operation(summary = "기억 상세 조회", description = "기억 ID를 기준으로 기억 상세 정보를 조회합니다.")
     @GetMapping("/{memoryId}")
@@ -137,6 +139,19 @@ public class MemoryController {
             @RequestParam String tagName
     ) {
         List<MemorySearchResponse> response = searchMemoryByTagUseCase.execute(tagName);
+
+        return CommonResponse.success(
+                ResponseMessage.MEMORY_FETCHED,
+                response
+        );
+    }
+
+    @Operation(summary = "장소별 기억 검색", description = "특정 장소명으로 기억 목록을 조회합니다.")
+    @GetMapping("/search/location")
+    public CommonResponse<List<MemorySearchResponse>> searchMemoryByLocation(
+            @RequestParam String location
+    ) {
+        List<MemorySearchResponse> response = searchMemoryByLocationUseCase.execute(location);
 
         return CommonResponse.success(
                 ResponseMessage.MEMORY_FETCHED,


### PR DESCRIPTION
## Summary
- `SearchMemoryByLocationUseCase` 추가
- `GET /api/memories/search/location?location={장소명}` 엔드포인트 추가
- 기존 `MemoryGetService.getMemoriesByLocation()` 재사용

## Test plan
- [x] `GET /api/memories/search/location?location=서울` 호출 시 해당 장소의 기억 목록 반환 확인
- [x] 존재하지 않는 장소 조회 시 빈 배열 반환 확인

