### PR TITLE
feat: 기억 및 기록 삭제 API 구현

### DIFF
--- a/src/main/java/ReDay/common/response/ResponseMessage.java
+++ b/src/main/java/ReDay/common/response/ResponseMessage.java
@@ -29,6 +29,7 @@ public enum ResponseMessage {
     MEMORY_ANALYSIS_GET_SUCCESS(305, "기억 분석 조회 성공"),
 
     MEMORY_NOT_FOUND(400, "기억을 찾을 수 없습니다."),
+    RECORD_NOT_FOUND(401, "기록을 찾을 수 없습니다."),
     MEMORY_ACCESS_DENIED(401, "해당 기억에 접근할 권한이 없습니다."),
     MEMORY_ANALYSIS_FAILED(500, "기억 분석에 실패했습니다."),
 

--- a/src/main/java/ReDay/memory/presentation/MemoryController.java
+++ b/src/main/java/ReDay/memory/presentation/MemoryController.java
@@ -9,6 +9,7 @@ import ReDay.memory.application.dto.response.MemoryListResponse;
 import ReDay.memory.application.dto.response.MemorySearchResponse;
 import ReDay.memory.application.dto.response.MemoryCalendarResponse;
 import ReDay.memory.application.dto.response.MemoryTagListResponse;
+import ReDay.memory.application.usecase.DeleteMemoryUseCase;
 import ReDay.memory.application.usecase.CreateMemoryUseCase;
 import ReDay.memory.application.usecase.GetAllTagsUseCase;
 import ReDay.memory.application.usecase.GetMemoryByDateUseCase;
@@ -23,6 +24,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/memories")
 public class MemoryController {
 
+    private final DeleteMemoryUseCase deleteMemoryUseCase;
     private final GetMemoryDetailUseCase getMemoryDetailUseCase;
     private final CreateMemoryUseCase createMemoryUseCase;
     private final GetMemoryListUseCase getMemoryListUseCase;
@@ -46,6 +49,14 @@ public class MemoryController {
     private final GetAllTagsUseCase getAllTagsUseCase;
     private final SearchMemoryByTagUseCase searchMemoryByTagUseCase;
     private final SearchMemoryByLocationUseCase searchMemoryByLocationUseCase;
+
+    @Operation(summary = "기억 삭제", description = "기억 ID를 기준으로 기억을 삭제합니다.")
+    @DeleteMapping("/{memoryId}")
+    public CommonResponse<Void> deleteMemory(@PathVariable Long memoryId) {
+        deleteMemoryUseCase.execute(memoryId);
+
+        return CommonResponse.success(ResponseMessage.MEMORY_DELETED, null);
+    }
 
     @Operation(summary = "기억 상세 조회", description = "기억 ID를 기준으로 기억 상세 정보를 조회합니다.")
     @GetMapping("/{memoryId}")

--- a/src/main/java/ReDay/record/application/exception/RecordNotFoundException.java
+++ b/src/main/java/ReDay/record/application/exception/RecordNotFoundException.java
@@ -1,0 +1,11 @@
+package ReDay.record.application.exception;
+
+import ReDay.application.exception.BusinessException;
+import ReDay.common.response.ResponseMessage;
+
+public class RecordNotFoundException extends BusinessException {
+
+    public RecordNotFoundException() {
+        super(ResponseMessage.RECORD_NOT_FOUND);
+    }
+}

--- a/src/main/java/ReDay/record/application/usecase/DeleteRecordUseCase.java
+++ b/src/main/java/ReDay/record/application/usecase/DeleteRecordUseCase.java
@@ -1,0 +1,16 @@
+package ReDay.record.application.usecase;
+
+import ReDay.record.domain.service.RecordDeleteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteRecordUseCase {
+
+    private final RecordDeleteService recordDeleteService;
+
+    public void execute(Long recordId) {
+        recordDeleteService.delete(recordId);
+    }
+}

--- a/src/main/java/ReDay/record/domain/service/RecordDeleteService.java
+++ b/src/main/java/ReDay/record/domain/service/RecordDeleteService.java
@@ -1,0 +1,23 @@
+package ReDay.record.domain.service;
+
+import ReDay.record.application.exception.RecordNotFoundException;
+import ReDay.record.domain.entity.Record;
+import ReDay.record.domain.repository.RecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecordDeleteService {
+
+    private final RecordRepository recordRepository;
+
+    public void delete(Long recordId) {
+        Record record = recordRepository.findById(recordId)
+                .orElseThrow(RecordNotFoundException::new);
+
+        recordRepository.delete(record);
+    }
+}

--- a/src/main/java/ReDay/record/presentation/RecordController.java
+++ b/src/main/java/ReDay/record/presentation/RecordController.java
@@ -4,6 +4,7 @@ import ReDay.common.response.CommonResponse;
 import ReDay.common.response.ResponseMessage;
 import ReDay.record.application.dto.request.TextRecordRequest;
 import ReDay.record.application.dto.response.RecordSaveResponse;
+import ReDay.record.application.usecase.DeleteRecordUseCase;
 import ReDay.record.application.usecase.SavePhotoRecordUseCase;
 import ReDay.record.application.usecase.SaveTextRecordUseCase;
 import ReDay.record.application.usecase.SaveVoiceRecordUseCase;
@@ -17,6 +18,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,9 +34,18 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/records")
 public class RecordController {
 
+    private final DeleteRecordUseCase deleteRecordUseCase;
     private final SaveTextRecordUseCase saveTextRecordUseCase;
     private final SavePhotoRecordUseCase savePhotoRecordUseCase;
     private final SaveVoiceRecordUseCase saveVoiceRecordUseCase;
+
+    @Operation(summary = "기록 삭제")
+    @DeleteMapping("/{recordId}")
+    public CommonResponse<Void> deleteRecord(@PathVariable Long recordId) {
+        deleteRecordUseCase.execute(recordId);
+
+        return CommonResponse.success(ResponseMessage.RECORD_DELETED, null);
+    }
 
     @Operation(summary = "텍스트 기록 저장")
     @PostMapping("/text")


### PR DESCRIPTION
## Summary
- `DELETE /api/memories/{memoryId}` 엔드포인트 추가
- `DELETE /api/records/{recordId}` 엔드포인트 추가
- `RecordDeleteService`, `DeleteRecordUseCase`, `RecordNotFoundException` 신규 구현
- `ResponseMessage`에 `RECORD_NOT_FOUND` 추가

## Test plan
- [x] `DELETE /api/memories/{memoryId}` 호출 시 기억 삭제 확인
- [x] `DELETE /api/records/{recordId}` 호출 시 기록 삭제 확인
- [x] 존재하지 않는 ID 요청 시 404 에러 반환 확인

