### PR TITLE
feat: 알림 기능 구현

### DIFF
--- a/src/main/java/ReDay/common/response/ResponseMessage.java
+++ b/src/main/java/ReDay/common/response/ResponseMessage.java
@@ -34,7 +34,14 @@ public enum ResponseMessage {
     MEMORY_ANALYSIS_FAILED(500, "기억 분석에 실패했습니다."),
 
     // Analysis
-    ANALYSIS_FETCHED(600, "분석 조회 성공");
+    ANALYSIS_FETCHED(600, "분석 조회 성공"),
+
+    // Notification
+    NOTIFICATION_FETCHED(700, "알림 목록을 조회했습니다."),
+    NOTIFICATION_READ(701, "알림을 읽음 처리했습니다."),
+    NOTIFICATION_SETTING_FETCHED(702, "알림 설정을 조회했습니다."),
+    NOTIFICATION_SETTING_UPDATED(703, "알림 설정이 변경되었습니다."),
+    NOTIFICATION_NOT_FOUND(704, "알림을 찾을 수 없습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/ReDay/notification/application/dto/request/NotificationSettingRequest.java
+++ b/src/main/java/ReDay/notification/application/dto/request/NotificationSettingRequest.java
@@ -1,0 +1,8 @@
+package ReDay.notification.application.dto.request;
+
+public record NotificationSettingRequest(
+        boolean pushEnabled,
+        boolean dailyRecordEnabled,
+        boolean aiGenerationEnabled
+) {
+}

--- a/src/main/java/ReDay/notification/application/dto/response/NotificationResponse.java
+++ b/src/main/java/ReDay/notification/application/dto/response/NotificationResponse.java
@@ -1,0 +1,14 @@
+package ReDay.notification.application.dto.response;
+
+import ReDay.notification.domain.entity.NotificationType;
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long notificationId,
+        NotificationType type,
+        String title,
+        String content,
+        boolean isRead,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/ReDay/notification/application/dto/response/NotificationSettingResponse.java
+++ b/src/main/java/ReDay/notification/application/dto/response/NotificationSettingResponse.java
@@ -1,0 +1,8 @@
+package ReDay.notification.application.dto.response;
+
+public record NotificationSettingResponse(
+        boolean pushEnabled,
+        boolean dailyRecordEnabled,
+        boolean aiGenerationEnabled
+) {
+}

--- a/src/main/java/ReDay/notification/application/exception/NotificationNotFoundException.java
+++ b/src/main/java/ReDay/notification/application/exception/NotificationNotFoundException.java
@@ -1,0 +1,11 @@
+package ReDay.notification.application.exception;
+
+import ReDay.application.exception.BusinessException;
+import ReDay.common.response.ResponseMessage;
+
+public class NotificationNotFoundException extends BusinessException {
+
+    public NotificationNotFoundException() {
+        super(ResponseMessage.NOTIFICATION_NOT_FOUND);
+    }
+}

--- a/src/main/java/ReDay/notification/application/usecase/GetNotificationSettingUseCase.java
+++ b/src/main/java/ReDay/notification/application/usecase/GetNotificationSettingUseCase.java
@@ -1,0 +1,24 @@
+package ReDay.notification.application.usecase;
+
+import ReDay.notification.application.dto.response.NotificationSettingResponse;
+import ReDay.notification.domain.entity.NotificationSetting;
+import ReDay.notification.domain.service.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetNotificationSettingUseCase {
+
+    private final NotificationSettingService notificationSettingService;
+
+    public NotificationSettingResponse execute(Long userId) {
+        NotificationSetting setting = notificationSettingService.getSetting(userId);
+
+        return new NotificationSettingResponse(
+                setting.isPushEnabled(),
+                setting.isDailyRecordEnabled(),
+                setting.isAiGenerationEnabled()
+        );
+    }
+}

--- a/src/main/java/ReDay/notification/application/usecase/GetNotificationsUseCase.java
+++ b/src/main/java/ReDay/notification/application/usecase/GetNotificationsUseCase.java
@@ -1,0 +1,33 @@
+package ReDay.notification.application.usecase;
+
+import ReDay.notification.application.dto.response.NotificationResponse;
+import ReDay.notification.domain.entity.Notification;
+import ReDay.notification.domain.service.NotificationGetService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetNotificationsUseCase {
+
+    private final NotificationGetService notificationGetService;
+
+    public List<NotificationResponse> execute(Long userId) {
+        return notificationGetService.getNotifications(userId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private NotificationResponse toResponse(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getType(),
+                notification.getTitle(),
+                notification.getContent(),
+                notification.isRead(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/ReDay/notification/application/usecase/ReadNotificationUseCase.java
+++ b/src/main/java/ReDay/notification/application/usecase/ReadNotificationUseCase.java
@@ -1,0 +1,16 @@
+package ReDay.notification.application.usecase;
+
+import ReDay.notification.domain.service.NotificationReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReadNotificationUseCase {
+
+    private final NotificationReadService notificationReadService;
+
+    public void execute(Long notificationId) {
+        notificationReadService.markAsRead(notificationId);
+    }
+}

--- a/src/main/java/ReDay/notification/application/usecase/UpdateNotificationSettingUseCase.java
+++ b/src/main/java/ReDay/notification/application/usecase/UpdateNotificationSettingUseCase.java
@@ -1,0 +1,30 @@
+package ReDay.notification.application.usecase;
+
+import ReDay.notification.application.dto.request.NotificationSettingRequest;
+import ReDay.notification.application.dto.response.NotificationSettingResponse;
+import ReDay.notification.domain.entity.NotificationSetting;
+import ReDay.notification.domain.service.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateNotificationSettingUseCase {
+
+    private final NotificationSettingService notificationSettingService;
+
+    public NotificationSettingResponse execute(Long userId, NotificationSettingRequest request) {
+        NotificationSetting setting = notificationSettingService.updateSetting(
+                userId,
+                request.pushEnabled(),
+                request.dailyRecordEnabled(),
+                request.aiGenerationEnabled()
+        );
+
+        return new NotificationSettingResponse(
+                setting.isPushEnabled(),
+                setting.isDailyRecordEnabled(),
+                setting.isAiGenerationEnabled()
+        );
+    }
+}

--- a/src/main/java/ReDay/notification/domain/entity/Notification.java
+++ b/src/main/java/ReDay/notification/domain/entity/Notification.java
@@ -1,0 +1,55 @@
+package ReDay.notification.domain.entity;
+
+import ReDay.domain.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, length = 255)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    @Builder
+    private Notification(Long userId, NotificationType type, String title, String content) {
+        this.userId = userId;
+        this.type = type;
+        this.title = title;
+        this.content = content;
+        this.isRead = false;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/ReDay/notification/domain/entity/NotificationSetting.java
+++ b/src/main/java/ReDay/notification/domain/entity/NotificationSetting.java
@@ -1,0 +1,50 @@
+package ReDay.notification.domain.entity;
+
+import ReDay.domain.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notification_setting")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSetting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false)
+    private boolean pushEnabled;
+
+    @Column(nullable = false)
+    private boolean dailyRecordEnabled;
+
+    @Column(nullable = false)
+    private boolean aiGenerationEnabled;
+
+    @Builder
+    private NotificationSetting(Long userId) {
+        this.userId = userId;
+        this.pushEnabled = true;
+        this.dailyRecordEnabled = true;
+        this.aiGenerationEnabled = true;
+    }
+
+    public void update(boolean pushEnabled, boolean dailyRecordEnabled, boolean aiGenerationEnabled) {
+        this.pushEnabled = pushEnabled;
+        this.dailyRecordEnabled = dailyRecordEnabled;
+        this.aiGenerationEnabled = aiGenerationEnabled;
+    }
+}

--- a/src/main/java/ReDay/notification/domain/entity/NotificationType.java
+++ b/src/main/java/ReDay/notification/domain/entity/NotificationType.java
@@ -1,0 +1,8 @@
+package ReDay.notification.domain.entity;
+
+public enum NotificationType {
+    AI_GENERATION,
+    DAILY_RECORD,
+    NEW_FEATURE,
+    MAINTENANCE
+}

--- a/src/main/java/ReDay/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/ReDay/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package ReDay.notification.domain.repository;
+
+import ReDay.notification.domain.entity.Notification;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/ReDay/notification/domain/repository/NotificationSettingRepository.java
+++ b/src/main/java/ReDay/notification/domain/repository/NotificationSettingRepository.java
@@ -1,0 +1,10 @@
+package ReDay.notification.domain.repository;
+
+import ReDay.notification.domain.entity.NotificationSetting;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+    Optional<NotificationSetting> findByUserId(Long userId);
+}

--- a/src/main/java/ReDay/notification/domain/service/NotificationGetService.java
+++ b/src/main/java/ReDay/notification/domain/service/NotificationGetService.java
@@ -1,0 +1,26 @@
+package ReDay.notification.domain.service;
+
+import ReDay.notification.application.exception.NotificationNotFoundException;
+import ReDay.notification.domain.entity.Notification;
+import ReDay.notification.domain.repository.NotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationGetService {
+
+    private final NotificationRepository notificationRepository;
+
+    public List<Notification> getNotifications(Long userId) {
+        return notificationRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    public Notification getNotification(Long notificationId) {
+        return notificationRepository.findById(notificationId)
+                .orElseThrow(NotificationNotFoundException::new);
+    }
+}

--- a/src/main/java/ReDay/notification/domain/service/NotificationReadService.java
+++ b/src/main/java/ReDay/notification/domain/service/NotificationReadService.java
@@ -1,0 +1,23 @@
+package ReDay.notification.domain.service;
+
+import ReDay.notification.application.exception.NotificationNotFoundException;
+import ReDay.notification.domain.entity.Notification;
+import ReDay.notification.domain.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationReadService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void markAsRead(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(NotificationNotFoundException::new);
+
+        notification.markAsRead();
+    }
+}

--- a/src/main/java/ReDay/notification/domain/service/NotificationSettingService.java
+++ b/src/main/java/ReDay/notification/domain/service/NotificationSettingService.java
@@ -1,0 +1,32 @@
+package ReDay.notification.domain.service;
+
+import ReDay.notification.domain.entity.NotificationSetting;
+import ReDay.notification.domain.repository.NotificationSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    @Transactional(readOnly = true)
+    public NotificationSetting getSetting(Long userId) {
+        return notificationSettingRepository.findByUserId(userId)
+                .orElseGet(() -> NotificationSetting.builder().userId(userId).build());
+    }
+
+    @Transactional
+    public NotificationSetting updateSetting(Long userId, boolean pushEnabled,
+            boolean dailyRecordEnabled, boolean aiGenerationEnabled) {
+        NotificationSetting setting = notificationSettingRepository.findByUserId(userId)
+                .orElseGet(() -> notificationSettingRepository.save(
+                        NotificationSetting.builder().userId(userId).build()
+                ));
+
+        setting.update(pushEnabled, dailyRecordEnabled, aiGenerationEnabled);
+        return setting;
+    }
+}

--- a/src/main/java/ReDay/notification/presentation/NotificationController.java
+++ b/src/main/java/ReDay/notification/presentation/NotificationController.java
@@ -1,0 +1,76 @@
+package ReDay.notification.presentation;
+
+import ReDay.common.response.CommonResponse;
+import ReDay.common.response.ResponseMessage;
+import ReDay.notification.application.dto.request.NotificationSettingRequest;
+import ReDay.notification.application.dto.response.NotificationResponse;
+import ReDay.notification.application.dto.response.NotificationSettingResponse;
+import ReDay.notification.application.usecase.GetNotificationSettingUseCase;
+import ReDay.notification.application.usecase.GetNotificationsUseCase;
+import ReDay.notification.application.usecase.ReadNotificationUseCase;
+import ReDay.notification.application.usecase.UpdateNotificationSettingUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Notification", description = "알림 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final GetNotificationsUseCase getNotificationsUseCase;
+    private final ReadNotificationUseCase readNotificationUseCase;
+    private final GetNotificationSettingUseCase getNotificationSettingUseCase;
+    private final UpdateNotificationSettingUseCase updateNotificationSettingUseCase;
+
+    @Operation(summary = "알림 목록 조회", description = "사용자의 알림 목록을 최신순으로 조회합니다.")
+    @GetMapping
+    public CommonResponse<List<NotificationResponse>> getNotifications(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<NotificationResponse> response = getNotificationsUseCase.execute(userId);
+
+        return CommonResponse.success(ResponseMessage.NOTIFICATION_FETCHED, response);
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 처리합니다.")
+    @PatchMapping("/{notificationId}/read")
+    public CommonResponse<Void> readNotification(
+            @PathVariable Long notificationId
+    ) {
+        readNotificationUseCase.execute(notificationId);
+
+        return CommonResponse.success(ResponseMessage.NOTIFICATION_READ, null);
+    }
+
+    @Operation(summary = "알림 설정 조회", description = "사용자의 알림 설정을 조회합니다.")
+    @GetMapping("/settings")
+    public CommonResponse<NotificationSettingResponse> getNotificationSetting(
+            @AuthenticationPrincipal Long userId
+    ) {
+        NotificationSettingResponse response = getNotificationSettingUseCase.execute(userId);
+
+        return CommonResponse.success(ResponseMessage.NOTIFICATION_SETTING_FETCHED, response);
+    }
+
+    @Operation(summary = "알림 설정 변경", description = "사용자의 알림 설정을 변경합니다.")
+    @PutMapping("/settings")
+    public CommonResponse<NotificationSettingResponse> updateNotificationSetting(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody NotificationSettingRequest request
+    ) {
+        NotificationSettingResponse response = updateNotificationSettingUseCase.execute(userId, request);
+
+        return CommonResponse.success(ResponseMessage.NOTIFICATION_SETTING_UPDATED, response);
+    }
+}


### PR DESCRIPTION
## Summary
- `Notification`, `NotificationSetting` 엔티티 추가
- `GET /api/notifications` — 알림 목록 조회 (최신순, 읽음 여부 포함)
- `PATCH /api/notifications/{notificationId}/read` — 알림 읽음 처리
- `GET /api/notifications/settings` — 알림 설정 조회
- `PUT /api/notifications/settings` — 알림 설정 변경 (푸시/기억 미작성/AI 생성 미완료)

## Test plan
- [x] 알림 목록 조회 시 읽음/안읽음 구분 확인
- [x] 읽음 처리 후 `isRead: true` 반환 확인
- [x] 존재하지 않는 알림 읽음 처리 시 404 확인
- [x] 알림 설정 변경 후 반영 확인
- [x] 알림 설정 미존재 시 기본값(모두 true) 반환 확인

