### PR TITLE
fix: RecordController PathVariable import 누락 수정

### DIFF
--- a/src/main/java/ReDay/record/presentation/RecordController.java
+++ b/src/main/java/ReDay/record/presentation/RecordController.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;


### PR DESCRIPTION
## Summary
- `RecordController`에 `@PathVariable` import 누락으로 빌드 실패 수정
- PR #34, #36 배포 실패 원인

