### PR TITLE
Fix: 타임존 Asia/Seoul(KST) 설정

### DIFF
--- a/src/main/java/ReDay/ReDayApplication.java
+++ b/src/main/java/ReDay/ReDayApplication.java
@@ -1,5 +1,7 @@
 package ReDay;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -7,6 +9,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 @SpringBootApplication
 public class ReDayApplication {
+
+	@PostConstruct
+	public void setTimeZone() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(ReDayApplication.class, args);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,8 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
 
   data:
     web:


### PR DESCRIPTION
## Summary
- 문의사항 등 날짜·시간 9시간 차이 문제 수정
- JVM 기본 타임존 `Asia/Seoul` 설정 (`@PostConstruct`)
- JPA hibernate `jdbc.time_zone` `Asia/Seoul` 설정
- closes #53

## Test plan
- [x] 문의사항 생성 후 날짜·시간이 KST 기준으로 정상 표시되는지 확인