### PR TITLE
Fix: 기억 생성 시 AI 처리 로그 저장 누락 수정

### DIFF
--- a/src/main/java/ReDay/memory/application/usecase/CreateMemoryUseCase.java
+++ b/src/main/java/ReDay/memory/application/usecase/CreateMemoryUseCase.java
@@ -3,11 +3,14 @@ package ReDay.memory.application.usecase;
 import ReDay.memory.application.dto.request.MemorySaveRequest;
 import ReDay.memory.application.dto.response.MemoryListResponse;
 import ReDay.memory.application.mapper.MemoryMapper;
+import ReDay.memory.domain.entity.AiProcessingLog;
 import ReDay.memory.domain.entity.Memory;
+import ReDay.memory.domain.repository.AiProcessingLogRepository;
 import ReDay.memory.domain.service.MemorySaveService;
 import ReDay.memory.infrastructure.AiEmbeddingClient;
 import ReDay.notification.domain.entity.NotificationType;
 import ReDay.notification.domain.service.NotificationSaveService;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -19,8 +22,10 @@ public class CreateMemoryUseCase {
     private final MemorySaveService memorySaveService;
     private final NotificationSaveService notificationSaveService;
     private final AiEmbeddingClient aiEmbeddingClient;
+    private final AiProcessingLogRepository aiProcessingLogRepository;
 
     public MemoryListResponse execute(Long userId, MemorySaveRequest request) {
+        long startMs = System.currentTimeMillis();
         Memory memory = memorySaveService.save(userId, request);
 
         List<String> tags = request.tags() != null ? request.tags() : List.of();
@@ -35,6 +40,14 @@ public class CreateMemoryUseCase {
                 memory.getMemoryDate() + "에 추가한 기억이 아직 완성되지 않았어요",
                 memory.getId()
         );
+
+        aiProcessingLogRepository.save(AiProcessingLog.builder()
+                .memoryId(memory.getId())
+                .userId(userId)
+                .status("SUCCESS")
+                .responseTimeMs(System.currentTimeMillis() - startMs)
+                .processedAt(LocalDateTime.now())
+                .build());
 
         return MemoryMapper.toMemoryListResponse(memory, 0, tags, people);
     }


### PR DESCRIPTION
## Summary
- 관리자 AI 처리 로그에 기억 생성 내역이 표시되지 않는 문제 수정
- `CreateMemoryUseCase`에 `AiProcessingLog` 저장 로직 추가
- closes #55

## Test plan
- [x] 기억 생성 후 관리자 AI 처리 로그 조회 시 해당 기억 생성 로그 표시 확인